### PR TITLE
Upgrade thecodingmachine/safe dependency to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,23 +19,23 @@
     }
   ],
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "ext-json": "*",
     "composer/semver": "^3.0",
     "zoon/rialto": "^1.5",
     "psr/log": "^3.0",
-    "thecodingmachine/safe": "^2.5"
+    "thecodingmachine/safe": "^3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.2",
     "monolog/monolog": "^3.0",
-    "phpstan/phpstan": "^1.10",
+    "phpstan/phpstan": "^2.0",
     "phpunit/phpunit": "^11",
     "symfony/console": "^7",
     "symfony/filesystem": "^7",
     "symfony/process": "^7",
     "symfony/var-dumper": "^7",
-    "thecodingmachine/phpstan-safe-rule": "^1.2"
+    "thecodingmachine/phpstan-safe-rule": "^1.4"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
As of February 11th, thecodingmachine/safe v3.0 has been released and is fully compatible with PHP 8.4, but drops support for version 8.0. All tests run successfully after the upgrade.
