### PR TITLE
Updated the `safe` package to version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "composer/semver": "^3.0",
     "zoon/rialto": "^1.5",
     "psr/log": "^3.0",
-    "thecodingmachine/safe": "^2.5"
+    "thecodingmachine/safe": "^3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.2",


### PR DESCRIPTION
The older version of `thecodingmachine/safe` causes PHP 8.4 to throw deprecation notices everywhere. This PR fixes the problem.